### PR TITLE
Use 5-column index as required for Sphinx version >1.4

### DIFF
--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -245,7 +245,8 @@ class DylanDescDirective (DescDirective):
         indexentry = str(shortname)
         if shortname != specname:
             indexentry += u"; {0}".format(specname)
-        self.indexnode['entries'].append(('single', indexentry, fullid, ''))
+        self.indexnode['entries'].append(('single', indexentry,
+                                          fullid, '', None))
 
     def warn_and_raise_error (self, error):
         src, srcline = self.state.state_machine.get_source_and_line()


### PR DESCRIPTION
When building the docs, Sphinx shows hundreds of warnings of the type

    WARNING: 4 column based index found. It might be a bug of extensions you use: 

This is because the API of Sphinx has changed. This PR fixes the warning by adding a fifth value to the tuple as required by the new API.