### PR TITLE
Update absolutify_urls.py to match newer version of html5lib.

### DIFF
--- a/feed/sphinxcontrib/feed/absolutify_urls.py
+++ b/feed/sphinxcontrib/feed/absolutify_urls.py
@@ -69,7 +69,7 @@ to BASE_URL. Return the body of the result as HTML."""
     # want the <HEAD>: this breaks feed readers).
     body = dom.getElementsByTagName('body')[0]
     tree_walker = html5lib.treewalkers.getTreeWalker('dom')
-    html_serializer = html5lib.serializer.htmlserializer.HTMLSerializer()
+    html_serializer = html5lib.serializer.HTMLSerializer()
     return u''.join(html_serializer.serialize(tree_walker(body)))
     
 


### PR DESCRIPTION
@pedro-w if you have a moment could you try building the dylan-lang/website repo after pulling this into the sphinx-extensions submodule?  (But first, is the build broken for you without this?  It looks like it will depend on your version of html5lib.)