### PR TITLE
doc: Fix 'dylan_drm_url' to avoid redirect warnings in 'make linkcheck'.

### DIFF
--- a/sphinxcontrib/dylan/domain/__init__.py
+++ b/sphinxcontrib/dylan/domain/__init__.py
@@ -11,5 +11,5 @@ Copyright (c) 2011-2016 Open Dylan Maintainers. All rights reserved.
 from .dylandomain import DylanDomain
 
 def setup (app):
-    app.add_config_value('dylan_drm_url', 'http://opendylan.org/books/drm/', 'html')
+    app.add_config_value('dylan_drm_url', 'https://opendylan.org/books/drm/', 'html')
     app.add_domain(DylanDomain)


### PR DESCRIPTION
Change 'http' to 'https' to avoid redirect warnings doing 'make linkcheck'.