### PR TITLE
feat: Convert multi word `:drm:` reference to a single word reference

### DIFF
--- a/sphinxcontrib/dylan/domain/drmindex.py
+++ b/sphinxcontrib/dylan/domain/drmindex.py
@@ -2,7 +2,7 @@
 """,
 drmindex.py
 
-Copyright (c) 2011-2016 Open Dylan Maintainers. All rights reserved.
+Copyright (c) 2011-2019 Open Dylan Maintainers. All rights reserved.
 """,
 
 index = {
@@ -268,9 +268,10 @@ index = {
   "method": "Statement_Macros#method",
   "<type>": "Type_Classes#type",
   "<class>": "Type_Classes#class",
-  "<singleton>": "Type_Classes#singleton"
+  "<singleton>": "Type_Classes#singleton",
+  "afterwards": "Statement_Macros#block"
 }
 
 def lookup(key):
-  return index.get(key.lower(), key)
+  return index.get(key.lower().replace(" ","_"), key)
 

--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -35,11 +35,11 @@ from . import drmindex
 
 
 def drm_link (name, rawtext, text, lineno, inliner, options={}, context=[]):
-    match = RE.match(r'^(\S+)$|^(.*)\s<(\S+)>$', text, flags=RE.DOTALL)
+    match = RE.match(r'^(.*)\s<(\S+)>$|^(.*)$', text, flags=RE.DOTALL)
     if match:
         base_url = inliner.document.settings.env.app.config.dylan_drm_url
 
-        linkkey1, linktext, linkkey2 = match.groups()
+        linktext, linkkey1, linkkey2 = match.groups()
         linkkey = linkkey1 or linkkey2
         linktext = (linktext or linkkey).strip()
         location = drmindex.lookup(linkkey)
@@ -53,7 +53,7 @@ def drm_link (name, rawtext, text, lineno, inliner, options={}, context=[]):
     else:
         msg = inliner.reporter.error(
             'Invalid syntax for :dylan:drm: role; '
-            '`{0}` should be like `ref` or `text <ref>`.'.format(text),
+            '`{0}` should be like `ref` (one or more words) or `text <ref>`.'.format(text),
             line=lineno)
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]


### PR DESCRIPTION
A `:drm:` link is a single word reference, i.e. `:drm:`block`, or several
words (text) followed by the reference between brackets, i.e. `:drm:`foo bar
<reference>`.

Therefore, every multi-word link has to be repeated first as separated words
and then as one word linked with underscores (by convention),
i.e. `:drm:`define sealed domain <define_domain_sealed>`.

To avoid the repetition, the lookup key is converted to a single word,
replacing white spaces with underscores.

The regular expression used to match the links is changed too.  The previous
one matched `ref` or `text <ref>`, and the new one matches `text <ref>` and
`ref ... [ref ...]`, i.e. `:drm:``define sealed domain``.