### PR TITLE
Don't modify dict whilst iterating through it

### DIFF
--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -742,12 +742,15 @@ class DylanDomain (Domain):
     ]
 
     def clear_doc(self, docname):
-        for fullid, (objects_docname, _, _, _, specname, _) in self.data['objects'].items():
+        objects = self.data['objects']
+        for fullid in list(objects):
+            (objects_docname, _, _, _, specname, _) = objects[fullid]
             if objects_docname == docname:
-                del self.data['objects'][fullid]
+                del objects[fullid]
                 specid = name_to_id(specname)
-                if fullid in self.data['fullids'].get(specid, {}):
-                    self.data['fullids'][specid].remove(fullid)
+                ids = self.data['fullids'].get(specid, [])
+                if fullid in ids:
+                    ids.remove(fullid)
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         if typ == 'ref':


### PR DESCRIPTION
I've noticed this error when rebuilding the docs:
```
Exception occurred:
  File "...\opendylan\documentation\sphinx-extensions\sphinxcontrib\dylan\domain\dylandomain.py", line 745, in clear_doc
    for fullid, (objects_docname, _, _, _, specname, _) in self.data['objects'].items():
RuntimeError: dictionary changed size during iteration
```
it is because the `clear_doc()` function is (potentially) deleting elements from `self.data['objects']` at the same time as iterating through it.
The attached PR fixes this.