### PR TITLE
Toc entries for definitions

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -4,15 +4,10 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# Use the local repo to build the docs, as a very minimal test.
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../sphinxcontrib'))
 
 
 # -- Project information -----------------------------------------------------
@@ -22,7 +17,7 @@ copyright = '2022, Dylan Hackers'
 author = 'Dylan Hackers'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.2.0'
+release = 'v1.1.0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -31,7 +26,9 @@ release = 'v0.2.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'dylan.domain',
 ]
+primary_domain = 'dylan'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -52,4 +49,4 @@ html_theme = 'furo'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -451,6 +451,17 @@ Directive options
 Directive options appear immediately after the directive with no intervening
 blank lines.
 
+``:no-contents-entry:``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+   Tells Sphinx not to add a Table of Contents (ToC) entry for this Dylan object.  This
+   may be especially useful for `dylan:method::`_ directives because sometimes they can
+   unnecessarily clutter the ToC. If the `dylan:method::`_ directives are all colocated
+   with the `dylan:generic-function::`_ directive then it may be sufficient to only
+   include the latter in the ToC. (This option is provided by Sphinx itself.)
+
+   :Syntax: ``:no-contents-entry:``
+
 ``:library:``
 ^^^^^^^^^^^^^
 

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -36,6 +36,14 @@ Roles
    configured by `dylan_drm_index`_. The partial URL is appended to the base URL
    configured by the `dylan_drm_url`_.
 
+   For example, this link to :drm:`<object>` was produced with the markup
+   ``:drm:`<object>```, which assumes the above configuration setting of ``primary_domain
+   = 'dylan'``.
+
+.. The above usage of the :drm: role is explicitly included as a very minimal test to
+   make sure that when this documentation is built it at least uses some of the code in
+   dylandomain.py; please don't remove it.
+
 
 Configurables
 -------------
@@ -53,7 +61,7 @@ Configurables
    partial URLs. Each line is a correspondence. The first word is the Dylan
    name, followed by whitespace, then the remainder is the partial URL. Defaults
    to partial URLs corresponding to the copy of the `Dylan Reference Manual`:t:
-   at `<http://opendylan.org>`_.
+   at `opendylan.org <https://opendylan.org>`_.
 
 
 Library, module, and binding documentation

--- a/sphinxcontrib/dylan/domain/__init__.py
+++ b/sphinxcontrib/dylan/domain/__init__.py
@@ -11,5 +11,7 @@ Copyright (c) 2011-2025 Dylan Hackers. All rights reserved.
 from .dylandomain import DylanDomain
 
 def setup (app):
+    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_config_value
     app.add_config_value('dylan_drm_url', 'https://opendylan.org/books/drm/', 'html')
+    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_domain
     app.add_domain(DylanDomain)

--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -168,11 +168,17 @@ class DylanDescDirective (ObjectDescription):
     option_spec.update(dict({'synopsis': DIRECTIVES.unchanged}.items()))
 
     doc_field_types = [
-        Field('summary', label="Summary", has_arg=False,
+        Field('summary',
+              label="Summary",
+              has_arg=False,
               names=('summary')),
-        Field('discussion', label="Discussion", has_arg=False,
+        Field('discussion',
+              label="Discussion",
+              has_arg=False,
               names=('discussion', 'description')),
-        Field('seealso', label="See also", has_arg=False,
+        Field('seealso',
+              label="See also",
+              has_arg=False,
               names=('seealso',)),
     ] + ObjectDescription.doc_field_types
 
@@ -321,7 +327,9 @@ class DylanBindingDesc (DylanDescDirective):
     }.items()))
 
     doc_field_types = [
-        Field('example', label="Example", has_arg=False,
+        Field('example',
+              label="Example",
+              has_arg=False,
               names=('example')),
     ] + DylanDescDirective.doc_field_types
 
@@ -367,16 +375,24 @@ class DylanClassDesc (DylanBindingDesc):
     }.items()))
 
     doc_field_types = [
-        Field('superclasses', label="Superclasses", has_arg=False,
+        Field('superclasses',
+              label="Superclasses",
+              has_arg=False,
               names=('supers', 'superclasses', 'super', 'superclass')),
-        TypedField('keyword', label="Init-Keywords",
+        TypedField('keyword',
+                   label="Init-Keywords",
                    names=('keyword', 'init-keyword')),
-        GroupedField('slots', label="Slots",
+        GroupedField('slots',
+                     label="Slots",
                      names=('slot', 'getter')),
-        Field('conditions', label="Conditions", has_arg=False,
+        Field('conditions',
+              label="Conditions",
+              has_arg=False,
               names=('conditions', 'exceptions', 'condition', 'exception',
                      'signals', 'throws')),
-        Field('operations', label="Operations", has_arg=False,
+        Field('operations',
+              label="Operations",
+              has_arg=False,
               names=('operations', 'methods', 'functions')),
     ] + DylanBindingDesc.doc_field_types
 
@@ -385,13 +401,19 @@ class DylanFunctionDesc (DylanBindingDesc):
     """A Dylan function, method, or generic function."""
 
     doc_field_types = [
-        TypedField('parameters', label="Parameters",
+        TypedField('parameters',
+                   label="Parameters",
                    names=('param', 'parameter')),
-        GroupedField('values', label="Values",
+        GroupedField('values',
+                     label="Values",
                      names=('value', 'val', 'retval', 'return')),
-        Field('signature', label="Signature", has_arg=False,
+        Field('signature',
+              label="Signature",
+              has_arg=False,
               names=('sig', 'signature')),
-        Field('conditions', label="Conditions", has_arg=False,
+        Field('conditions',
+              label="Conditions",
+              has_arg=False,
               names=('conditions', 'exceptions', 'signals', 'throws')),
     ] + DylanBindingDesc.doc_field_types
 
@@ -452,9 +474,11 @@ class DylanConstOrVarDesc (DylanBindingDesc):
     """A Dylan constant or variable."""
 
     doc_field_types = [
-        Field('type', label="Type",
+        Field('type',
+              label="Type",
               names=('type')),
-        Field('value', label="Value",
+        Field('value',
+              label="Value",
               names=('value', 'val'))
     ] + DylanBindingDesc.doc_field_types
 
@@ -470,11 +494,17 @@ class DylanTypeDesc (DylanConstOrVarDesc):
     display_name ="type"
 
     doc_field_types = [
-        Field('supertypes', label="Supertypes", has_arg=False,
+        Field('supertypes',
+              label="Supertypes",
+              has_arg=False,
               names=('supers', 'supertypes', 'super', 'supertype')),
-        Field('equivalent', label="Equivalent", has_arg=False,
+        Field('equivalent',
+              label="Equivalent",
+              has_arg=False,
               names=('equivalent')),
-        Field('operations', label="Operations", has_arg=False,
+        Field('operations',
+              label="Operations",
+              has_arg=False,
               names=('operations', 'methods', 'functions')),
     ] + DylanConstOrVarDesc.doc_field_types
 
@@ -514,11 +544,15 @@ class DylanMacroDesc (DylanBindingDesc):
     }.items()))
 
     doc_field_types = [
-        TypedField('parameters', label="Parameters",
+        TypedField('parameters',
+                   label="Parameters",
                    names=('param', 'parameter')),
-        GroupedField('values', label="Values",
+        GroupedField('values',
+                     label="Values",
                      names=('value', 'val', 'retval', 'return')),
-        Field('call', label="Macro Call", has_arg=False,
+        Field('call',
+              label="Macro Call",
+              has_arg=False,
               names=('call', 'macrocall', 'syntax'))
     ] + DylanBindingDesc.doc_field_types
 
@@ -680,48 +714,48 @@ class DylanDomain (Domain):
     label = 'Dylan'
 
     roles = {
-        'drm': drm_link,
-        'lib': desc_link,
-        'mod': desc_link,
-        'class': desc_link,
-        'var': desc_link,
-        'const': desc_link,
-        'func': desc_link,
-        'meth': desc_link,
-        'gf': desc_link,
-        'macro': desc_link,
-        'prim': desc_link,
-        'type': desc_link,
+        'drm':    drm_link,
+        'lib':    desc_link,
+        'mod':    desc_link,
+        'class':  desc_link,
+        'var':    desc_link,
+        'const':  desc_link,
+        'func':   desc_link,
+        'meth':   desc_link,
+        'gf':     desc_link,
+        'macro':  desc_link,
+        'prim':   desc_link,
+        'type':   desc_link,
     }
 
     directives = {
-        'current-library': DylanCurrentLibrary,
-        'current-module': DylanCurrentModule,
-        'library': DylanLibraryDesc,
-        'module': DylanModuleDesc,
-        'class': DylanClassDesc,
-        'variable': DylanVariableDesc,
-        'constant': DylanConstantDesc,
-        'function': DylanConstFuncDesc,
-        'method': DylanMethodDesc,
-        'generic-function': DylanGenFuncDesc,
-        'primitive': DylanPrimitiveDesc,
-        'macro': DylanMacroDesc,
-        'type': DylanTypeDesc,
+        'current-library':   DylanCurrentLibrary,
+        'current-module':    DylanCurrentModule,
+        'library':           DylanLibraryDesc,
+        'module':            DylanModuleDesc,
+        'class':             DylanClassDesc,
+        'variable':          DylanVariableDesc,
+        'constant':          DylanConstantDesc,
+        'function':          DylanConstFuncDesc,
+        'method':            DylanMethodDesc,
+        'generic-function':  DylanGenFuncDesc,
+        'primitive':         DylanPrimitiveDesc,
+        'macro':             DylanMacroDesc,
+        'type':              DylanTypeDesc,
     }
 
     object_types = {
-        'library':  ObjType('library', 'lib'),
-        'module':   ObjType('module', 'mod'),
-        'class':    ObjType('class', 'class'),
-        'variable': ObjType('variable', 'var'),
-        'constant': ObjType('constant', 'const'),
-        'function': ObjType('function', 'func'),
-        'method':   ObjType('method', 'meth'),
-        'generic-function': ObjType('generic-function', 'gf'),
-        'primitive': ObjType('primitive', 'prim'),
-        'macro':    ObjType('macro', 'macro'),
-        'type':     ObjType('type', 'type'),
+        'library':           ObjType('library', 'lib'),
+        'module':            ObjType('module', 'mod'),
+        'class':             ObjType('class', 'class'),
+        'variable':          ObjType('variable', 'var'),
+        'constant':          ObjType('constant', 'const'),
+        'function':          ObjType('function', 'func'),
+        'method':            ObjType('method', 'meth'),
+        'generic-function':  ObjType('generic-function', 'gf'),
+        'primitive':         ObjType('primitive', 'prim'),
+        'macro':             ObjType('macro', 'macro'),
+        'type':              ObjType('type', 'type'),
     }
 
     initial_data = {

--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -12,11 +12,11 @@ try:
 except ImportError:
     from urllib.parse import urljoin
 
+import docutils
 import docutils.nodes as RST_NODES
 import docutils.parsers.rst.directives as DIRECTIVES
 import sphinx.addnodes as SPHINX_NODES
 
-from docutils.parsers.rst.roles import set_classes
 from docutils.parsers.rst import Directive
 from sphinx.domains import Domain, Index
 from sphinx.domains import ObjType
@@ -45,7 +45,7 @@ def drm_link (name, rawtext, text, lineno, inliner, options={}, context=[]):
         location = drmindex.lookup(linkkey)
         href = urljoin(base_url, location)
 
-        set_classes(options)
+        options = docutils.parsers.rst.roles.normalized_role_options(options)
         textnode = RST_NODES.literal(rawtext, linktext, classes=['xref', 'drm'])
         linknode = RST_NODES.reference('', '', refuri=href, **options)
         linknode += textnode


### PR DESCRIPTION
This adds table of contents entries for all `DylanDomain` directives like `.. func::`.  Example from strings library:
<img width="189" alt="toc-more" src="https://github.com/user-attachments/assets/11034eef-2180-40b6-b6d4-8e7bbb2cf61f" />

I built the OD docs with this and it looks great as far as I can tell.