### PR TITLE
bug: DRM link with multiwords

### DIFF
--- a/sphinxcontrib/dylan/domain/dylandomain.py
+++ b/sphinxcontrib/dylan/domain/dylandomain.py
@@ -35,7 +35,7 @@ from . import drmindex
 
 
 def drm_link (name, rawtext, text, lineno, inliner, options={}, context=[]):
-    match = re.match(r'^(.*)\s<(\S+)>$|^(.*)$', text, flags=re.DOTALL)
+    match = re.match(r'^(.*)\s<([^>]+)>$|^(.*)$', text, flags=re.DOTALL)
     if match:
         base_url = inliner.document.settings.env.app.config.dylan_drm_url
 


### PR DESCRIPTION
':drm:`specific examples <define module>`' produces a wrong link https://opendylan.org/books/drm/specific%20examples%20%3Cdefine%20module%3E

The second regular expression is matched capturing all the text.

This PR substitutes the regular expression.
Fixes dylan-lang/opendylan#1610